### PR TITLE
put image below main text content blocks on small screens

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -115,6 +115,11 @@ body, html {
     margin-bottom: 2rem;
     align-items: start;
 }
+@media (max-width: 700px) {
+    .section {
+        flex-direction: column;
+    }
+}
 .section-text {
     flex: 1;
     padding-right: 2rem;


### PR DESCRIPTION
| before | after |
|-----|----|
| <a href="https://github.com/user-attachments/assets/26b054db-0cbf-4b41-aad5-1aec0c43df28"><img src="https://github.com/user-attachments/assets/26b054db-0cbf-4b41-aad5-1aec0c43df28" width="200" /></a> | <a href="https://github.com/user-attachments/assets/8d701e06-232c-4f61-be10-f26a1e431fad"><img src="https://github.com/user-attachments/assets/8d701e06-232c-4f61-be10-f26a1e431fad" width="200" /></a> |